### PR TITLE
Update rubyzip version to a at least 1.0.0

### DIFF
--- a/docx_generator.gemspec
+++ b/docx_generator.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
   
-  spec.add_runtime_dependency "rubyzip"
+  spec.add_runtime_dependency "rubyzip", '>= 1'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/docx_generator.rb
+++ b/lib/docx_generator.rb
@@ -2,7 +2,7 @@ require 'docx_generator/version'
 require 'docx_generator/element'
 require 'docx_generator/word'
 require 'docx_generator/dsl'
-require 'zip/zip'
+require 'zip'
 
 # Main module of the library.
 module DocxGenerator

--- a/lib/docx_generator/dsl/document.rb
+++ b/lib/docx_generator/dsl/document.rb
@@ -71,7 +71,7 @@ EOF
 
         def generate_archive(content_types, rels, document)
           File.delete(@filename) if File.exists?(@filename)
-          Zip::ZipFile.open(@filename, Zip::ZipFile::CREATE) do |docx|
+          Zip::File.open(@filename, Zip::File::CREATE) do |docx|
             docx.mkdir('_rels')
             docx.mkdir('word')
             docx.get_output_stream('[Content_Types].xml') { |f| f.puts content_types }

--- a/spec/docx_generator/dsl/document_spec.rb
+++ b/spec/docx_generator/dsl/document_spec.rb
@@ -30,19 +30,19 @@ describe DocxGenerator::DSL::Document do
       before { DocxGenerator::DSL::Document.new("word").save }
     
       it "should generate a [Content_Types].xml file" do
-        Zip::ZipFile.open("word.docx") do |docx|
+        Zip::File.open("word.docx") do |docx|
           expect { docx.read("[Content_Types].xml") }.to_not raise_error
         end
       end
       
       it "should generate a _rels/.rels file" do
-        Zip::ZipFile.open("word.docx") do |docx|
+        Zip::File.open("word.docx") do |docx|
           expect { docx.read("_rels/.rels") }.to_not raise_error
         end
       end
       
       it "should generate a word/document.xml" do
-        Zip::ZipFile.open("word.docx") do |docx|
+        Zip::File.open("word.docx") do |docx|
           expect { docx.read("word/document.xml") }.to_not raise_error
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'docx_generator'
 
 def open_file(file)
-  Zip::ZipFile.open("word.docx") do |docx|
+  Zip::File.open("word.docx") do |docx|
     docx.read(file)
   end
 end


### PR DESCRIPTION
The Zip::ZipFile class was changed to Zip::File, and the require directive was changed `require 'zip'`
I also fixed all the specs and added a constaint to rubyzip dependency.

Details are at https://github.com/rubyzip/rubyzip
